### PR TITLE
Correct .env

### DIFF
--- a/example.env.local
+++ b/example.env.local
@@ -2,8 +2,6 @@
 NEXT_PUBLIC_API_BASE_URL=https://api.gateway.tst.in.compell.io
 NEXT_PUBLIC_SESSION_KEY=etherlink
 
-# Image Server Configuration
-NEXT_PUBLIC_IMAGE_SERVER_URL=http://127.0.0.1:8080/
 
 # S3 Bucket for Assets
 NEXT_PUBLIC_S3_BUCKET_URL=https://dcap-viewer-assets.s3.eu-central-1.amazonaws.com

--- a/example.env.local
+++ b/example.env.local
@@ -2,7 +2,6 @@
 NEXT_PUBLIC_API_BASE_URL=https://api.gateway.tst.in.compell.io
 NEXT_PUBLIC_SESSION_KEY=etherlink
 
-
 # S3 Bucket for Assets
 NEXT_PUBLIC_S3_BUCKET_URL=https://dcap-viewer-assets.s3.eu-central-1.amazonaws.com
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,12 +10,6 @@ const getHostname = (url: string): string => {
   }
 };
 
-// Get image server hostname from environment
-const imageServerUrl = process.env.NEXT_PUBLIC_IMAGE_SERVER_URL || 'http://127.0.0.1:8080/';
-const imageServerHostname = getHostname(imageServerUrl);
-const imageServerPort = process.env.NEXT_PUBLIC_IMAGE_SERVER_URL 
-  ? new URL(process.env.NEXT_PUBLIC_IMAGE_SERVER_URL).port 
-  : '8080';
 
 // S3 bucket for DCAPv2 images
 const s3BucketUrl = process.env.NEXT_PUBLIC_S3_BUCKET_URL || 'https://dcap-viewer-assets.s3.eu-central-1.amazonaws.com';
@@ -23,14 +17,8 @@ const s3BucketDomain = getHostname(s3BucketUrl);
 
 const nextConfig: NextConfig = {
   images: {
-    domains: [imageServerHostname, s3BucketDomain],
+    domains: [s3BucketDomain],
     remotePatterns: [
-      {
-        protocol: 'http',
-        hostname: imageServerHostname,
-        port: imageServerPort,
-        pathname: '/**',
-      },
       {
         protocol: 'https',
         hostname: s3BucketDomain,


### PR DESCRIPTION
@GoatOfRafin inquired about the `NEXT_PUBLIC_IMAGE_SERVER_URL` variable in `example.env.local`. After verifying, I confirmed it’s no longer used. It was originally needed for fully local development but became obsolete after we switched to hosting assets in our S3 bucket.

This PR removes `NEXT_PUBLIC_IMAGE_SERVER_URL` entirely - from `example.env.local` and from the Next.js configuration.